### PR TITLE
adding correct FOE organisation's URI

### DIFF
--- a/pipeline/patch.csv
+++ b/pipeline/patch.csv
@@ -377,3 +377,4 @@ brownfield-land,,OrganisationURI,"click here to go to the city council entry on 
 brownfield-land,,OrganisationURI,south norfolk,http://opendatacommunities.org/id/district-council/south-norfolk
 brownfield-land,,OrganisationURI,https://local-authority-eng.register.gov.uk/record/RIB,http://opendatacommunities.org/id/district-council/ribble-valley
 brownfield-land,,OrganisationURI,http://opendatacommunities.org.id/unitary-authority/herefordshire,http://opendatacommunities.org/id/county-council/hertfordshire
+brownfield-land,,OrganisationURI,http://opendatacommu nities.org/id/districtcouncil/forest-of-dean,http://opendatacommunities.org/id/district-council/forest-of-dean


### PR DESCRIPTION
FOE organisation's URI is incorrect in the data provided by LPA. So made this change in patch.csv to take the correct URI.

Ticket reference: https://trello.com/c/PNEL0xN9/314-investigating-missing-organization-lookup-issues-that-came-up-while-adding-brownfield-land-endpoints